### PR TITLE
Add basic Python support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ If you want to see more languages or added, open a ticket, or feel free to do a 
 * Add the choice of active keyword per language in the settings
 * Add sidebar resizing
 * Add more languages/symbols :
-  * python
   * ruby
   * shell
   * java

--- a/lib/symbols-list-regex.coffee
+++ b/lib/symbols-list-regex.coffee
@@ -37,3 +37,8 @@ module.exports =
         ini:
             regex:
                 structure: /^\[([^\]]+)]/gmi
+        python:
+            regex:
+                commentaire: /^[^\S\n]*# ! (.+)/gmi
+                class: /^[^\S\n]*class ([\w]+):/gmi
+                function: /^[^\S\n]*def ([\w]+ *\(.*\)):/gmi


### PR DESCRIPTION
Hi:

I added some basic support for Python symbols—comments, classes, and functions are now supported.