### PR TITLE
Improve Python source regex strings

### DIFF
--- a/lib/symbols-list-regex.coffee
+++ b/lib/symbols-list-regex.coffee
@@ -46,8 +46,8 @@ module.exports =
             regex:
                 commentaire: /^[^\S\n]*# ! (.+)/gmi
                 class: /^[^\S\n]*class[\W]+([\w]+)(:| *\([\w\s.,]*\):)/gmi
-                function: /^[^\S\n]*def[\W]+([\w]+ *\((?!self)[\w\s.,=()[\]{}*]*\)):/gmi
-                method: /^[^\S\n]*def[\W]+([\w]+ *\(self[\w\s.,=()[\]{}*]*\)):/gmi
+                function: /^[^\S\n]*def +([\w]+ *\((?!\s*self\s*(?=(,|\))))(.|\s)*?\)):/gmi
+                method: /^[^\S\n]*def +([\w]+ *\((?=\s*self\s*(?=(,|\))))(.|\s)*?\)):/gmi
         ruby:
             regex:
                 attr: /^[^\S\n]*(?:attr_reader|attr_writer|attr_accessor) ([\w:]+)/gmi

--- a/lib/symbols-list-regex.coffee
+++ b/lib/symbols-list-regex.coffee
@@ -45,8 +45,9 @@ module.exports =
         python:
             regex:
                 commentaire: /^[^\S\n]*# ! (.+)/gmi
-                class: /^[^\S\n]*class ([\w]+):/gmi
-                function: /^[^\S\n]*def ([\w]+ *\(.*\)):/gmi
+                class: /^[^\S\n]*class[\W]+([\w]+)(:| *\([\w\s.,]*\):)/gmi
+                function: /^[^\S\n]*def[\W]+([\w]+ *\((?!self)[\w\s.,=()[\]{}*]*\)):/gmi
+                method: /^[^\S\n]*def[\W]+([\w]+ *\(self[\w\s.,=()[\]{}*]*\)):/gmi
         ruby:
             regex:
                 attr: /^[^\S\n]*(?:attr_reader|attr_writer|attr_accessor) ([\w:]+)/gmi

--- a/tests/source/test.py
+++ b/tests/source/test.py
@@ -18,7 +18,8 @@ class OldStyleClass2():
 
 class Class3(object):
     """Doc string"""
-    pass
+    def __init__(self, param):
+        self.param = param
 
 
 class Class4(object):
@@ -30,6 +31,14 @@ class Class4(object):
         pass
 
     def _private_class_method(self):
+        pass
+
+    def class_method_multi_line1(
+            self):
+        pass
+
+    def class_method_multi_line2(
+            self, param1, param2):
         pass
 
     class Class4Nested(object):
@@ -49,7 +58,7 @@ def function1():
     return time.time()  # Inline comment
 
 
-def function2(param1, param2=None):
+def function2(param1, param2=Class3('%^$#'), param3=-4/2.0*3+1, param4='4', param5="5"):
 
     def function2_nested(param3, param4):
         return date(2000, 1, 1)
@@ -68,4 +77,8 @@ def function4_multi_line(
 
 def function5_multi_line(param1,
                          param2):
+    pass
+
+
+def function6_not_method(self_test):
     pass

--- a/tests/source/test.py
+++ b/tests/source/test.py
@@ -1,0 +1,71 @@
+"""Python test examples."""
+# ! commentaire 1
+# ! commentaire 2
+# Not commentaire
+
+import re
+import time
+from datetime import (datetime, date)
+
+
+class OldStyleClass1:
+    pass
+
+
+class OldStyleClass2():
+    pass
+
+
+class Class3(object):
+    """Doc string"""
+    pass
+
+
+class Class4(object):
+
+    def class_method(self):
+        pass
+
+    def class_method_many_params(self, param1, param2):
+        pass
+
+    def _private_class_method(self):
+        pass
+
+    class Class4Nested(object):
+        pass
+
+
+class Class5(re.RegexObject):
+    pass
+
+
+class Class6Multiline(Class3,
+                      Class4):
+    pass
+
+
+def function1():
+    return time.time()  # Inline comment
+
+
+def function2(param1, param2=None):
+
+    def function2_nested(param3, param4):
+        return date(2000, 1, 1)
+
+    pass
+
+
+def function3(*args, **kwargs):
+    return datetime(2000, 1, 1)
+
+
+def function4_multi_line(
+        param1, param2):
+    pass
+
+
+def function5_multi_line(param1,
+                         param2):
+    pass


### PR DESCRIPTION
This improves the support for Python a bit more:
- Classes defined with inheritance (or just parenthesis) are now working.
- Add support for functions defined over multiple lines.
- Try to extract functions in classes as methods (assume first parameter is `self`).
- Added a Python test file.

Before changes:
<img width="694" alt="symbols-list python before" src="https://cloud.githubusercontent.com/assets/20420754/19531798/4df20e72-9639-11e6-83c9-bc3176a6c32a.png">

After changes:
<img width="699" alt="symbols-list python after" src="https://cloud.githubusercontent.com/assets/20420754/19531810/595dfd48-9639-11e6-9998-f14ef8ca5fba.png">
