### PR TITLE
Support for css.tss

### DIFF
--- a/lib/symbols-list-regex.coffee
+++ b/lib/symbols-list-regex.coffee
@@ -21,6 +21,7 @@ module.exports =
         css:
             regex:
                 commentaire_multi: /^[^\S\n]*\/\* ! (.+)\*\//gmi
+                class: /^"([#|\.]*.+)"/gmi
         js:
             regex:
                 commentaire: /^[^\S\n]*\/\/ ! (.+)/gmi


### PR DESCRIPTION
Adding basic support for Appcelerator Titanium tss files (source css.tss).
I've put it in the css section because the source is `css.tss` and it will stop at `css` while parsing the scanRegex

![tss](https://cloud.githubusercontent.com/assets/4334997/21482519/372e1516-cb75-11e6-9ffd-bc47496e981d.png)

It is a CSS like syntax with `"name": {}`, `".name": {}` or `"#name": {}`