### PR TITLE
Closes #54: add distinct colors to the protected and private function icons

### DIFF
--- a/lib/symbols-list-regex.coffee
+++ b/lib/symbols-list-regex.coffee
@@ -16,8 +16,8 @@ module.exports =
                     class: /^[^\S\n]*class ([\w]+)/gmi
                     methode_statique: /^(?:final|abstract|private|protected|public|[^\S\n])*static\sfunction\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
                     function: /^(?:final|abstract|public|[^\S\n])*function\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
-                    private_function: /^private[^\S\n]+function\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
-                    protected_function: /^protected[^\S\n]+function\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
+                    private_function: /^[^\S\n]*private[^\S\n]+function\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
+                    protected_function: /^[^\S\n]*protected[^\S\n]+function\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
                     todo: /(?:\/\*|\/\/)[ ]*todo\:[ ]*(.+?)[ ]*(?:\*\/)?(?:[\r\n])/gmi
                     fixme: /(?:\/\*|\/\/)[ ]*fixme\:[ ]*(.+?)[ ]*(?:\*\/)?(?:[\r\n])/gmi
                     hack: /(?:\/\*|\/\/)[ ]*hack\:[ ]*(.+?)[ ]*(?:\*\/)?(?:[\r\n])/gmi

--- a/lib/symbols-list-regex.coffee
+++ b/lib/symbols-list-regex.coffee
@@ -15,7 +15,9 @@ module.exports =
                     commentaire_multi: /^[^\S\n]*\/\* ! (.+)[^\/]*\*\//gmi
                     class: /^[^\S\n]*class ([\w]+)/gmi
                     methode_statique: /^(?:final|abstract|private|protected|public|[^\S\n])*static\sfunction\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
-                    function: /^(?:final|abstract|private|protected|public|[^\S\n])*function\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
+                    function: /^(?:final|abstract|public|[^\S\n])*function\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
+                    private_function: /^(?:private|[^\S\n])*function\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
+                    protected_function: /^(?:protected|[^\S\n])*function\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
                     todo: /(?:\/\*|\/\/)[ ]*todo\:[ ]*(.+?)[ ]*(?:\*\/)?(?:[\r\n])/gmi
                     fixme: /(?:\/\*|\/\/)[ ]*fixme\:[ ]*(.+?)[ ]*(?:\*\/)?(?:[\r\n])/gmi
                     hack: /(?:\/\*|\/\/)[ ]*hack\:[ ]*(.+?)[ ]*(?:\*\/)?(?:[\r\n])/gmi
@@ -31,7 +33,9 @@ module.exports =
                 commentaire_multi: /^[^\S\n]*\/\* ! (.+)[^\/]*\*\//gmi
                 class: /^[^\S\n]*class ([\w]+(?: extends [\w]+)*)/gmi
                 class_expression: /^[^\S\n]*([\w]+)\s*=\s*class\s{/gmi
-                function: /^[^\S\n]*(?:final|static|abstract|private|protected|public|async|export|[^\S\n])*function\s?([\w]+ *\([^\)]*\))/gmi
+                function: /^[^\S\n]*(?:final|static|abstract|public|async|export|[^\S\n])*function\s?([\w]+ *\([^\)]*\))/gmi
+                private_function: /^[^\S\n]*(?:private|[^\S\n])*function\s?([\w]+ *\([^\)]*\))/gmi
+                protected_function: /^[^\S\n]*(?:protected|[^\S\n])*function\s?([\w]+ *\([^\)]*\))/gmi
                 controller: /^[^\S\n]*\.controller\s*\(\s*["']+([\w]+)["']+[\s,]*function/gmi
                 method: /^[^\S\n]*(?:.*)(\b\w+\b)\s*(?:=|:)\s*function/gmi
                 es6method: /^[^\S\n]*(?:[*][\s\n]+)?(?:async[\s\n]+)?(?!foreach|if|for|while|catch)([\w]+\s*\(.*\))[\s\n]*{/gmi
@@ -54,7 +58,9 @@ module.exports =
         cs:
             regex:
                 class: /^[\S\n]*(?:final|static|abstract|private|protected|public|[^\S\n])*\s?class\s([\w]+(\s?:\s?[\w]*)?)/gmi
-                function: /^[^\S\n]*(?:final|static|abstract|private|protected|public)*\s?(?:\w+\s)+(\w+\s*\([^\)]*\))[\s\n]*{/gmi
+                function: /^[^\S\n]*(?:final|static|abstract|public)*\s?(?:\w+\s)+(\w+\s*\([^\)]*\))[\s\n]*{/gmi
+                private_function: /^[^\S\n]*(?:private)*\s?(?:\w+\s)+(\w+\s*\([^\)]*\))[\s\n]*{/gmi
+                protected_function: /^[^\S\n]*(?:protected)*\s?(?:\w+\s)+(\w+\s*\([^\)]*\))[\s\n]*{/gmi
         ini:
             regex:
                 structure: /^\[([^\]]+)]/gmi

--- a/lib/symbols-list-regex.coffee
+++ b/lib/symbols-list-regex.coffee
@@ -16,8 +16,8 @@ module.exports =
                     class: /^[^\S\n]*class ([\w]+)/gmi
                     methode_statique: /^(?:final|abstract|private|protected|public|[^\S\n])*static\sfunction\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
                     function: /^(?:final|abstract|public|[^\S\n])*function\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
-                    private_function: /^(?:private|[^\S\n])*function\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
-                    protected_function: /^(?:protected|[^\S\n])*function\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
+                    private_function: /^private[^\S\n]+function\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
+                    protected_function: /^protected[^\S\n]+function\s?((?:&\s?)?[\w]+ *\([^\)]*\))/gmi
                     todo: /(?:\/\*|\/\/)[ ]*todo\:[ ]*(.+?)[ ]*(?:\*\/)?(?:[\r\n])/gmi
                     fixme: /(?:\/\*|\/\/)[ ]*fixme\:[ ]*(.+?)[ ]*(?:\*\/)?(?:[\r\n])/gmi
                     hack: /(?:\/\*|\/\/)[ ]*hack\:[ ]*(.+?)[ ]*(?:\*\/)?(?:[\r\n])/gmi
@@ -34,8 +34,8 @@ module.exports =
                 class: /^[^\S\n]*class ([\w]+(?: extends [\w]+)*)/gmi
                 class_expression: /^[^\S\n]*([\w]+)\s*=\s*class\s{/gmi
                 function: /^[^\S\n]*(?:final|static|abstract|public|async|export|[^\S\n])*function\s?([\w]+ *\([^\)]*\))/gmi
-                private_function: /^[^\S\n]*(?:private|[^\S\n])*function\s?([\w]+ *\([^\)]*\))/gmi
-                protected_function: /^[^\S\n]*(?:protected|[^\S\n])*function\s?([\w]+ *\([^\)]*\))/gmi
+                private_function: /^[^\S\n]*private[^\S\n]+function\s?([\w]+ *\([^\)]*\))/gmi
+                protected_function: /^[^\S\n]*protected[^\S\n]+function\s?([\w]+ *\([^\)]*\))/gmi
                 controller: /^[^\S\n]*\.controller\s*\(\s*["']+([\w]+)["']+[\s,]*function/gmi
                 method: /^[^\S\n]*(?:.*)(\b\w+\b)\s*(?:=|:)\s*function/gmi
                 es6method: /^[^\S\n]*(?:[*][\s\n]+)?(?:async[\s\n]+)?(?!foreach|if|for|while|catch)([\w]+\s*\(.*\))[\s\n]*{/gmi
@@ -59,8 +59,8 @@ module.exports =
             regex:
                 class: /^[\S\n]*(?:final|static|abstract|private|protected|public|[^\S\n])*\s?class\s([\w]+(\s?:\s?[\w]*)?)/gmi
                 function: /^[^\S\n]*(?:final|static|abstract|public)*\s?(?:\w+\s)+(\w+\s*\([^\)]*\))[\s\n]*{/gmi
-                private_function: /^[^\S\n]*(?:private)*\s?(?:\w+\s)+(\w+\s*\([^\)]*\))[\s\n]*{/gmi
-                protected_function: /^[^\S\n]*(?:protected)*\s?(?:\w+\s)+(\w+\s*\([^\)]*\))[\s\n]*{/gmi
+                private_function: /^[^\S\n]*private\s?(?:\w+\s)+(\w+\s*\([^\)]*\))[\s\n]*{/gmi
+                protected_function: /^[^\S\n]*protected\s?(?:\w+\s)+(\w+\s*\([^\)]*\))[\s\n]*{/gmi
         ini:
             regex:
                 structure: /^\[([^\]]+)]/gmi

--- a/styles/symbols-list.less
+++ b/styles/symbols-list.less
@@ -100,7 +100,11 @@
 .symbols-list .list-item-hack{ background: #7c0000 }
 .symbols-list .list-item-hack::before{ content: "!"; color: #FFF;}
 .symbols-list .list-item-function{ background: #3996e3 }
-.symbols-list .list-item-function::before{ content: "F"; color: #FFF;}
+.symbols-list .list-item-protected_function{ background: #e39339 }
+.symbols-list .list-item-private_function{ background: #e35139 }
+.symbols-list .list-item-function::before,
+    .symbols-list .list-item-protected_function::before,
+    .symbols-list .list-item-private_function::before{ content: "F"; color: #FFF;}
 .symbols-list .list-item-attr{ background: #3996e3 }
 .symbols-list .list-item-attr::before{ content: "A"; color: #FFF;}
 .symbols-list .list-item-filter{ background: #839595 }


### PR DESCRIPTION
There is no change for the regular function icon (blue: #3996e3).

Protected one is now orange: #e39339.
Private one is now red: #e35139.

![icon colors](https://user-images.githubusercontent.com/5494947/37350424-0f24b0be-26d9-11e8-9041-db014318ad49.png)
