### PR TITLE
Support Multiline Method Signatures in Javascript

### DIFF
--- a/lib/symbols-list-regex.coffee
+++ b/lib/symbols-list-regex.coffee
@@ -51,9 +51,9 @@ module.exports =
                 protected_function: /^[^\S\n]*protected[^\S\n]+function\s?([\w]+ *\([^\)]*\))/gmi
                 controller: /^[^\S\n]*\.controller\s*\(\s*["']+([\w]+)["']+[\s,]*function/gmi
                 method: /^[^\S\n]*(?:.*)(\b\w+\b)\s*(?:=|:)\s*function/gmi
-                es6_method: /^[^\S\n]*(?:[*][\s\n]+)?(?:(?:@\w+)[\s\n]+)*(?!foreach|if|for|while|catch)([\w]+\(.*\))[\s\n]*{/gmi
-                es6_async_method: /^[^\S\n]*(?:[*][\s\n]+)?(?:(?:@\w+)[\s\n]+)*(?:async[\s\n]+)(?!foreach|if|for|while|catch)([\w]+\(.*\))[\s\n]*{/gmi
-                es6_static_method: /^[^\S\n]*(?:[*][\s\n]+)?(?:(?:@\w+)[\s\n]+)*(?:static[\s\n]+)(?!foreach|if|for|while|catch)([\w]+\(.*\))[\s\n]*{/gmi
+                es6_method: /^[^\S\n]*(?:[*][\s\n]+)?(?:(?:@\w+)[\s\n]+)*(?!foreach|if|for|while|catch)([\w]+\((?:(?!function|=>|;).|\n)*?\))\s{/gmi
+                es6_async_method: /^[^\S\n]*(?:[*][\s\n]+)?(?:(?:@\w+)[\s\n]+)*(?:async[\s\n]+)(?!foreach|if|for|while|catch)([\w]+\((?:.|\s)*?\))[\s\n]*{/gmi
+                es6_static_method: /^[^\S\n]*(?:[*][\s\n]+)?(?:(?:@\w+)[\s\n]+)*(?:static[\s\n]+)(?!foreach|if|for|while|catch)([\w]+\((?:.|\s)*?\))[\s\n]*{/gmi
                 constant: /^[^\S\n]*\.constant\(["']+([\w]+)["']+/gmi
                 filter: /^[^\S\n]*\.filter\(["']+([\w]+)["']+/gmi
                 structure: /^[^\S\n]*\.(config|run)\(function/gmi

--- a/tests/source/test.js
+++ b/tests/source/test.js
@@ -11,6 +11,11 @@ function Function2( arg1, arg2 ) {
 
 }
 
+function Function2Multiline( arg1,
+  arg2 ) {
+
+}
+
 private function Function3() {
 
 }
@@ -36,6 +41,24 @@ $scope.method = function() {
 });
 
 class SomeClass {
+    async longfn(a,
+      b
+    ) {
+
+    }
+
+    static longfn2(a,
+      b
+    ) {
+
+    }
+
+    longfn3(a,
+      b
+    ) {
+
+    }
+
     set foo(value) {
 
     }


### PR DESCRIPTION
Some tools like ESLint with the [max-len](https://eslint.org/docs/rules/max-len) rule enabled can produce method signatures like this:

<img width="631" alt="bildschirmfoto 2019-01-30 um 13 21 27" src="https://user-images.githubusercontent.com/6976170/51981037-0f2ddd80-2492-11e9-91c6-70b73d664efe.png">

I've adapted the regular expressions to match this and tried to reduce false positives like these:

```
test();

if () {

}
```

```
each(properties, property => {

});
```