### PR TITLE
Improve Focus, Unfocus and Selection UX

### DIFF
--- a/keymaps/symbols-list.json
+++ b/keymaps/symbols-list.json
@@ -4,5 +4,9 @@
   },
   ".platform-win32, .platform-linux": {
     "ctrl-alt-l": "symbols-list:toggle"
+  },
+  ".symbols-list atom-text-editor": {
+    "escape": "symbols-list:leave",
+    "shift-enter": "symbols-list:alt-confirm"
   }
 }

--- a/lib/symbols-list-view.coffee
+++ b/lib/symbols-list-view.coffee
@@ -41,7 +41,9 @@ module.exports =
             @filterEditorView.getModel().placeholderText = 'Start typing to filter...'
             @handleEvents()
 
-
+            atom.commands.add @element, 'symbols-list:alt-confirm': (event) =>
+                @altConfirmed()
+                event.stopPropagation()
 
         escapeHtml: (unsafe) ->
             if (! unsafe)
@@ -62,6 +64,12 @@ module.exports =
         confirmed: (item) ->
             if item.objet? and @callOnConfirm?
                 @callOnConfirm( item.range )
+
+        altConfirmed: () ->
+            item = @getSelectedItem()
+
+            if item.objet? and @callOnConfirm?
+                @callOnConfirm( item.range, true )
 
         cleanItems: () ->
             @items = []

--- a/lib/symbols-list.coffee
+++ b/lib/symbols-list.coffee
@@ -200,4 +200,11 @@ module.exports =
             @reloadSymbols()
 
     focus: ->
-      @SymbolsListView.focusFilterEditor()
+      current_selection = atom.workspace.getActiveTextEditor().getSelectedText();
+
+      if(current_selection)
+          @SymbolsListView.filterEditorView.setText(current_selection);
+      else
+          @SymbolsListView.filterEditorView.model.selectAll();
+
+      @SymbolsListView.focusFilterEditor();

--- a/lib/symbols-list.coffee
+++ b/lib/symbols-list.coffee
@@ -30,6 +30,7 @@ module.exports =
         # add event handlers
         @subscriptions = new CompositeDisposable
         @subscriptions.add atom.commands.add 'atom-workspace', 'symbols-list:toggle': => @toggle()
+        @subscriptions.add atom.commands.add 'atom-workspace', 'symbols-list:focus': => @focus()
         @subscriptions.add atom.workspace.onDidChangeActivePaneItem => @reloadSymbols()
         @subscriptions.add atom.workspace.observeTextEditors (editor) =>
             editor.onDidSave ->
@@ -197,3 +198,6 @@ module.exports =
             @panel.show()
             @isVisible = true
             @reloadSymbols()
+
+    focus: ->
+      @SymbolsListView.focusFilterEditor()


### PR DESCRIPTION
Improve UX by exposing **symbols-list:focus**, **symbols-list:leave**, **symbols-list:alt-confirmed** to the command palette.

* Optionally avoid mouse/trackpad usage to focus query field by assigning a keyboard shortcut to **symbols-list:focus**. On my Mac I personally use Cmd+e which works really nice.
  * it selects the previous query text so that it is easier to replace it and
  * uses the currently selected (main) editor text as query if applicable
* Leave sidebar by hitting ESC (**symbols-list:leave**)
* Confirm selection with Shift+Enter (**symbols-list:alt-confirmed**) and you'll leave the sidebar, empty the query text and repaint selected item so that it is easier to grasp context